### PR TITLE
Add "All" option for fetching indicator_metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Authors@R: c(person("Sebastian", "Fox", , "sebastian.fox@phe.gov.uk", c("aut", "
     person("Duncan", "Gormansway", , "nacnudus@gmail.com", c("ctb")),
     person("Carl", "Ganz", , "carlganz@gmail.com", c("ctb")),
     person("David", "Whiting", , "david.whiting@medway.gov.uk", c("ctb")),
+    person("Luke", "Bradley", , "dev.1b7@outlook.com", c("ctb")),
     person("Crown Copyright 2020", , , , c("cph")))
 URL: https://fingertips.phe.org.uk, 
     https://github.com/ropensci/fingertipsR, 

--- a/R/indicator_metadata.R
+++ b/R/indicator_metadata.R
@@ -74,6 +74,18 @@ indicator_metadata <- function(IndicatorID = NULL,
         fingertips_ensure_api_available(endpoint = path)
         if (!(is.null(IndicatorID))) {
                 AllIndicators <- indicators(path = path)
+
+                # https://fingertips.phe.org.uk/api#!/IndicatorMetadata/IndicatorMetadata_GetIndicatorMetadataFileForAllIndicators
+                if (IndicatorID == "All") {
+                        dataurl <- paste0(path, "indicator_metadata/csv/all")
+                        indicator_metadata <- dataurl %>%
+                                GET(use_proxy(ie_get_proxy_for_url(.), username = "", password = "", auth = "ntlm")) %>%
+                                content("parsed",
+                                        type = "text/csv",
+                                        encoding = "UTF-8",
+                                        col_types = types)
+                }
+
                 if (sum(AllIndicators$IndicatorID %in% IndicatorID) == 0){
                         stop("IndicatorID(s) do not exist, use indicators() to identify existing indicators")
                 }

--- a/R/indicator_metadata.R
+++ b/R/indicator_metadata.R
@@ -84,9 +84,7 @@ indicator_metadata <- function(IndicatorID = NULL,
                                         type = "text/csv",
                                         encoding = "UTF-8",
                                         col_types = types)
-                }
-
-                if (sum(AllIndicators$IndicatorID %in% IndicatorID) == 0){
+                } else if (sum(AllIndicators$IndicatorID %in% IndicatorID) == 0){
                         stop("IndicatorID(s) do not exist, use indicators() to identify existing indicators")
                 }
                 path <- paste0(path, "indicator_metadata/csv/by_indicator_id?indicator_ids=")

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -54,3 +54,7 @@ test_that("indicator_metadata returns correct number of columns when ProfileID a
 
 })
 
+test_that("indicator_metadata returns correct number of columns when IndicatorID option 'All' is supplied", {
+        skip_on_cran()
+        expect_equal(ncol(indicator_metadata(IndicatorID = "All"), ncols)
+})

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -56,5 +56,5 @@ test_that("indicator_metadata returns correct number of columns when ProfileID a
 
 test_that("indicator_metadata returns correct number of columns when IndicatorID option 'All' is supplied", {
         skip_on_cran()
-        expect_equal(ncol(indicator_metadata(IndicatorID = "All"), ncols)
+        expect_equal(ncol(indicator_metadata(IndicatorID = "All")), ncols)
 })


### PR DESCRIPTION
Hi, I've been using the fingertipsR library lately and had a situation where I needed the metadata for all the indicators; Fortunately [there's an endpoint for this](https://fingertips.phe.org.uk/api#!/IndicatorMetadata/IndicatorMetadata_GetIndicatorMetadataFileForAllIndicators) but it doesn't appear that fingertipsR supports this at the moment.

Rather than just adding an Issue, I thought I would try adding this option (like in fingertips_data( ..., AreaTypeID = "All") - I've not been able to test this patch properly as yet (sorry about that!), but I'm relatively confident this would work.

If there are additional steps I need to take ahead of submitting this PR, please feel free to let me know - this is the first time I've done so.

Thanks!